### PR TITLE
revert curl temp modifcation

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -25,11 +25,6 @@
 #include "curl_setup.h"
 #include "socketpair.h"
 
-#if __NuttX__
-#include <debug.h>
-#include <nuttx/pthread.h>
-#endif
-
 /***********************************************************************
  * Only for threaded name resolves builds
  **********************************************************************/
@@ -496,13 +491,6 @@ static CURLcode thread_wait_resolv(struct Curl_easy *data,
   td = data->state.async.tdata;
   DEBUGASSERT(td);
   DEBUGASSERT(td->thread_hnd != curl_thread_t_null);
-
-#if __NuttX__
-  if (report == FALSE) {
-    syslog(0,"thread_wait_resolv send %d SIGINT \n",*(td->thread_hnd));
-    pthread_kill(*(td->thread_hnd), SIGINT);
-  }
-#endif
 
   /* wait for the thread to resolve the name */
   if(Curl_thread_join(&td->thread_hnd)) {

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -498,8 +498,8 @@ static CURLcode thread_wait_resolv(struct Curl_easy *data,
   DEBUGASSERT(td->thread_hnd != curl_thread_t_null);
 
 #if __NuttX__
-  if (report == FALSE && !td->tsd.done) {
-    syslog(0,"thread_wait_resolv send %d SIGINT \n", *(td->thread_hnd));
+  if (report == FALSE) {
+    syslog(0,"thread_wait_resolv send %d SIGINT \n",*(td->thread_hnd));
     pthread_kill(*(td->thread_hnd), SIGINT);
   }
 #endif

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -26,10 +26,6 @@
 
 #include <curl/curl.h>
 
-#if __NuttX__
-#include <debug.h>
-#endif
-
 #ifdef HAVE_NETINET_IN_H
 #  include <netinet/in.h>
 #endif
@@ -92,14 +88,6 @@ Curl_freeaddrinfo(struct Curl_addrinfo *cahead)
 
 
 #ifdef HAVE_GETADDRINFO
-
-#if __NuttX__
-void dns_query_cancel(int signo)
-{
-  syslog(0,"dns_query_cancel \n");
-}
-#endif
-
 /*
  * Curl_getaddrinfo_ex()
  *
@@ -129,10 +117,6 @@ Curl_getaddrinfo_ex(const char *nodename,
   int error;
 
   *result = NULL; /* assume failure */
-
-#if __NuttX__
-  signal(SIGINT, dns_query_cancel);
-#endif
 
   error = getaddrinfo(nodename, servname, hints, &aihead);
   if(error)


### PR DESCRIPTION
### Summary
Reason for revert: In dev branch,c-ares has been supported，we don’t need to cancel dns query early

### Impact
curl

### Testing
Manual verification